### PR TITLE
Add better completion sorting and improve documentation signatures

### DIFF
--- a/pyls/plugins/jedi_completion/__init__.py
+++ b/pyls/plugins/jedi_completion/__init__.py
@@ -69,6 +69,7 @@ _ERRORS = ('error_node', )
 _LAST_COMPLETIONS = {}
 
 NAME_COUNTER = NameCounter()
+NAME_COUNTER.start()
 
 
 @hookimpl

--- a/pyls/plugins/jedi_completion/label_resolver.py
+++ b/pyls/plugins/jedi_completion/label_resolver.py
@@ -1,0 +1,70 @@
+# Copyright 2021 Michal Krassowski
+from collections import defaultdict
+from time import time
+
+from jedi.api.classes import Completion
+
+from .logger import log
+
+
+class LabelResolver:
+
+    def __init__(self, format_label, time_to_live=60 * 30):
+        self.format_label = format_label
+        self._cache = {}
+        self._time_to_live = time_to_live
+        self._cache_ttl = defaultdict(set)
+        self._clear_every = 2
+        # see https://github.com/davidhalter/jedi/blob/master/jedi/inference/helpers.py#L194-L202
+        self._cached_modules = {'pandas', 'numpy', 'tensorflow', 'matplotlib'}
+
+    def clear_outdated(self):
+        now = self.time_key()
+        to_clear = [
+            timestamp
+            for timestamp in self._cache_ttl
+            if timestamp < now
+        ]
+        for time_key in to_clear:
+            for key in self._cache_ttl[time_key]:
+                del self._cache[key]
+            del self._cache_ttl[time_key]
+
+    def time_key(self):
+        return int(time() / self._time_to_live)
+
+    def get_or_create(self, completion: Completion):
+        if not completion.full_name:
+            use_cache = False
+        else:
+            module_parts = completion.full_name.split('.')
+            use_cache = module_parts and module_parts[0] in self._cached_modules
+
+        if use_cache:
+            key = self._create_completion_id(completion)
+            if key not in self._cache:
+                if self.time_key() % self._clear_every == 0:
+                    self.clear_outdated()
+
+                self._cache[key] = self.resolve_label(completion)
+                self._cache_ttl[self.time_key()].add(key)
+            return self._cache[key]
+
+        return self.resolve_label(completion)
+
+    def _create_completion_id(self, completion: Completion):
+        return (
+            completion.full_name, completion.module_path,
+            completion.line, completion.column,
+            self.time_key()
+        )
+
+    def resolve_label(self, completion):
+        try:
+            sig = completion.get_signatures()
+            return self.format_label(completion, sig)
+        except Exception as e:  # pylint: disable=broad-except
+            log.warning(
+                'Something went wrong when resolving label for {completion}: {e}',
+                completion=completion, e=e
+            )

--- a/pyls/plugins/jedi_completion/logger.py
+++ b/pyls/plugins/jedi_completion/logger.py
@@ -1,0 +1,3 @@
+import logging
+
+log = logging.getLogger(__name__)

--- a/pyls/plugins/jedi_completion/name_counter.py
+++ b/pyls/plugins/jedi_completion/name_counter.py
@@ -25,6 +25,7 @@ class NameCounter(Thread):
             path, contents = self.queue.get()
             self._frequencies_by_document[path] = self._calculate_relative_frequencies(contents)
 
+    # pylint: disable=no-self-use
     @lru_cache(maxsize=5)
     def _calculate_relative_frequencies(self, contents: str) -> Dict[str, float]:
         """The most common one gets 1, the least common one gets 0."""

--- a/pyls/plugins/jedi_completion/name_counter.py
+++ b/pyls/plugins/jedi_completion/name_counter.py
@@ -1,0 +1,42 @@
+# Copyright 2021 Michal Krassowski
+import tokenize
+from collections import Counter
+from functools import lru_cache
+from io import StringIO
+from queue import Queue
+from threading import Thread
+from typing import Dict
+
+
+class NameCounter(Thread):
+
+    def __init__(self):
+        # TODO: maybe add time expiry to avoid leaks
+        self.queue = Queue()
+        self._frequencies_by_document: Dict[str, Dict[str, float]] = {}
+        super().__init__(daemon=True)
+
+    def get_frequencies(self, path: str, contents: str):
+        if not self.is_alive():
+            self.start()
+        self.queue.put_nowait((path, contents))
+        return self._frequencies_by_document.get(path, {})
+
+    def run(self):
+        while True:
+            path, contents = self.queue.get()
+            self._frequencies_by_document[path] = self._calculate_relative_frequencies(contents)
+
+    @lru_cache(maxsize=5)
+    def _calculate_relative_frequencies(self, contents: str) -> Dict[str, float]:
+        """The most common one gets 1, the least common one gets 0."""
+        counter = Counter([
+            token.string
+            for token in tokenize.generate_tokens(StringIO(contents).readline)
+            if token.type == tokenize.NAME
+        ])
+        most_common_count: int = counter.most_common(1)[0][1]
+        return {
+            name: count / most_common_count
+            for name, count in counter.items()
+        }

--- a/pyls/plugins/jedi_completion/sort.py
+++ b/pyls/plugins/jedi_completion/sort.py
@@ -3,8 +3,10 @@ from keyword import iskeyword
 from string import ascii_lowercase
 from typing import Dict
 try:
+    # pylint: disable=ungrouped-imports,useless-suppression
     from keyword import issoftkeyword
 except ImportError:
+    # pylint: disable=unused-argument
     def issoftkeyword(s: str):
         return False
 
@@ -24,7 +26,14 @@ def sort_text(definition: Completion, relative_frequencies: Dict[str, float] = N
         rarity = 1 - relative_frequencies[definition.name]
         # assign c-m for the frequency-based sorting
         # rarity = 0.5 will give 'h'
-        prefix = ascii_lowercase[round(rarity * 10) + 2]
+        priority = round(rarity * 10) + 2
+        # reduce the priority for hidden
+        if definition.name.startswith('_'):
+            priority += 1
+            # and double dunders
+            if definition.name.startswith('__'):
+                priority += 1
+        prefix = ascii_lowercase[priority + 2]
     elif definition.name.startswith('_'):
         if definition.name.startswith('__'):
             # move double dunders to the very bottom

--- a/pyls/plugins/jedi_completion/sort.py
+++ b/pyls/plugins/jedi_completion/sort.py
@@ -2,11 +2,16 @@
 from keyword import iskeyword
 from string import ascii_lowercase
 from typing import Dict
+try:
+    from keyword import issoftkeyword
+except ImportError:
+    def issoftkeyword(s: str):
+        return False
 
 from jedi.api.classes import Completion
 
 
-def sort_text(definition: Completion, relative_frequencies: Dict[str, float] = None, sort_by_count=False):
+def sort_text(definition: Completion, relative_frequencies: Dict[str, float] = None, sort_by_count=False) -> str:
     """Use frequency-based and rule-based sorting"""
     if not definition.name:
         # TODO: why would the name be None (it is allowed)?
@@ -17,8 +22,9 @@ def sort_text(definition: Completion, relative_frequencies: Dict[str, float] = N
     elif sort_by_count and definition.name in relative_frequencies:
         # frequency is a number between 0 and 1
         rarity = 1 - relative_frequencies[definition.name]
-        # assign a-j for the frequency-based sorting
-        prefix = ascii_lowercase[round(rarity * 10)]
+        # assign c-m for the frequency-based sorting
+        # rarity = 0.5 will give 'h'
+        prefix = ascii_lowercase[round(rarity * 10) + 2]
     elif definition.name.startswith('_'):
         if definition.name.startswith('__'):
             # move double dunders to the very bottom
@@ -27,10 +33,15 @@ def sort_text(definition: Completion, relative_frequencies: Dict[str, float] = N
             # move hidden properties down
             prefix = 'o'
     elif iskeyword(definition.name):
-        # show keywords near the top
+        # show genuine keywords near the top, but below parameters
         prefix = 'b'
+    elif issoftkeyword(definition.name):
+        # soft keywords get lower priority than keywords as these might
+        # include false positives, but get a higher probability than a
+        # an average word occurring in text (equivalent to rarity=0.25)
+        prefix = 'e'
     else:
         # this name does not appear in the document and is in now way special;
         # show it just after the names that appear in the documents
-        prefix = 'k'
+        prefix = 'n'
     return prefix + definition.name

--- a/pyls/plugins/jedi_completion/sort.py
+++ b/pyls/plugins/jedi_completion/sort.py
@@ -1,0 +1,36 @@
+# Copyright 2021 Michal Krassowski
+from keyword import iskeyword
+from string import ascii_lowercase
+from typing import Dict
+
+from jedi.api.classes import Completion
+
+
+def sort_text(definition: Completion, relative_frequencies: Dict[str, float] = None, sort_by_count=False):
+    """Use frequency-based and rule-based sorting"""
+    if not definition.name:
+        # TODO: why would the name be None (it is allowed)?
+        return 'z'
+
+    if definition.type == 'param':
+        prefix = 'a'
+    elif sort_by_count and definition.name in relative_frequencies:
+        # frequency is a number between 0 and 1
+        rarity = 1 - relative_frequencies[definition.name]
+        # assign a-j for the frequency-based sorting
+        prefix = ascii_lowercase[round(rarity * 10)]
+    elif definition.name.startswith('_'):
+        if definition.name.startswith('__'):
+            # move double dunders to the very bottom
+            prefix = 'z'
+        else:
+            # move hidden properties down
+            prefix = 'o'
+    elif iskeyword(definition.name):
+        # show keywords near the top
+        prefix = 'b'
+    else:
+        # this name does not appear in the document and is in now way special;
+        # show it just after the names that appear in the documents
+        prefix = 'k'
+    return prefix + definition.name

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -80,6 +80,11 @@
                     "default": 25,
                     "description": "How many labels at most should be resolved?"
                 },
+                "pyls.plugins.jedi_completion.sort_by_frequency": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Should sort completions using frequency of occurrences in the document?"
+                },
                 "pyls.plugins.jedi_definition.enabled": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
- do not use the text signatures when resolving documentation as those cannot be reliably counted/wrapped
- create from scratch a completion sorting algorithm that uses the frequency of occurrence of tokens and a few expert rules

[B. Barath, Improving Code Completion with Machine Learning, Imperial College London, 2020](https://www.imperial.ac.uk/media/imperial-college/faculty-of-engineering/computing/public/1920-ug-projects/distinguished-projects/ML-Code-Completion.pdf), shows that the default order of completions returned by jedi can improved by simple frequency (count)-based algorithm; they went ahead and also trained an LSTM but I think that a language server like pyls should not include ML models which may require very specific package versions and add dependencies which already are a struggle (such improvements should be provided by entry points plugins). As I do not have statistics for the tokens frequency for Python (and I am not sure how to generate one in legally safe way), I implemented something simpler, this is using the document at hand as a training set for the frequencies. If the completion has not occurred in the training set just simple expert rules are used instead.