### PR TITLE
Fix pylint errors and warnings after dropping Python 2.7

### DIFF
--- a/pyls/__main__.py
+++ b/pyls/__main__.py
@@ -71,26 +71,8 @@ def main():
 
 def _binary_stdio():
     """Construct binary stdio streams (not text mode).
-
-    This seems to be different for Window/Unix Python2/3, so going by:
-        https://stackoverflow.com/questions/2850893/reading-binary-data-from-stdin
     """
-    PY3K = sys.version_info >= (3, 0)
-
-    if PY3K:
-        # pylint: disable=no-member
-        stdin, stdout = sys.stdin.buffer, sys.stdout.buffer
-    else:
-        # Python 2 on Windows opens sys.stdin in text mode, and
-        # binary data that read from it becomes corrupted on \r\n
-        if sys.platform == "win32":
-            # set sys.stdin to binary mode
-            # pylint: disable=no-member,import-error
-            import os
-            import msvcrt
-            msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
-            msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
-        stdin, stdout = sys.stdin, sys.stdout
+    stdin, stdout = sys.stdin.buffer, sys.stdout.buffer
 
     return stdin, stdout
 

--- a/pyls/_utils.py
+++ b/pyls/_utils.py
@@ -6,6 +6,7 @@ import os
 import sys
 import threading
 
+import docstring_to_markdown
 import jedi
 
 PY2 = sys.version_info.major == 2
@@ -27,6 +28,7 @@ def debounce(interval_s, keyed_by=None):
 
         @functools.wraps(func)
         def debounced(*args, **kwargs):
+            # pylint: disable=deprecated-method
             call_args = inspect.getcallargs(func, *args, **kwargs)
             key = call_args[keyed_by] if keyed_by else None
 
@@ -100,11 +102,7 @@ def match_uri_to_workspace(uri, workspaces):
     max_len, chosen_workspace = -1, None
     path = pathlib.Path(uri).parts
     for workspace in workspaces:
-        try:
-            workspace_parts = pathlib.Path(workspace).parts
-        except TypeError:
-            # This can happen in Python2 if 'value' is a subclass of string
-            workspace_parts = pathlib.Path(unicode(workspace)).parts
+        workspace_parts = pathlib.Path(workspace).parts
         if len(workspace_parts) > len(path):
             continue
         match_len = 0
@@ -156,9 +154,8 @@ def format_docstring(contents, signature=None):
     if not contents:
         return contents
 
-    from docstring_to_markdown import convert, UnknownFormatError
     try:
-        value = convert(contents)
+        value = docstring_to_markdown.convert(contents)
         if signature:
             signatures = signature.split('\n')
             if len(signatures) > 2:
@@ -172,7 +169,7 @@ def format_docstring(contents, signature=None):
             if value.startswith(signature):
                 value = value[len(signature):]
             value = prefix + '\n\n' + value
-    except UnknownFormatError:
+    except docstring_to_markdown.UnknownFormatError:
         return contents.replace('\t', u'\u00A0' * 4).replace('  ', u'\u00A0' * 2)
 
     return {

--- a/pyls/config/config.py
+++ b/pyls/config/config.py
@@ -1,11 +1,7 @@
 # Copyright 2017 Palantir Technologies, Inc.
 import logging
+from functools import lru_cache
 import pkg_resources
-try:
-    from functools import lru_cache
-except ImportError:
-    from backports.functools_lru_cache import lru_cache
-
 import pluggy
 
 from pyls import _utils, hookspecs, uris, PYLS
@@ -16,7 +12,7 @@ log = logging.getLogger(__name__)
 DEFAULT_CONFIG_SOURCES = ['pycodestyle']
 
 
-class Config(object):
+class Config:
 
     def __init__(self, root_uri, init_opts, process_id, capabilities):
         self._root_path = uris.to_fs_path(root_uri)
@@ -30,11 +26,13 @@ class Config(object):
 
         self._config_sources = {}
         try:
+            # pylint: disable=import-outside-toplevel
             from .flake8_conf import Flake8Config
             self._config_sources['flake8'] = Flake8Config(self._root_path)
         except ImportError:
             pass
         try:
+            # pylint: disable=import-outside-toplevel
             from .pycodestyle_conf import PyCodeStyleConfig
             self._config_sources['pycodestyle'] = PyCodeStyleConfig(self._root_path)
         except ImportError:

--- a/pyls/config/source.py
+++ b/pyls/config/source.py
@@ -7,7 +7,7 @@ import sys
 log = logging.getLogger(__name__)
 
 
-class ConfigSource(object):
+class ConfigSource:
     """Base class for implementing a config source."""
 
     def __init__(self, root_path):

--- a/pyls/lsp.py
+++ b/pyls/lsp.py
@@ -3,10 +3,9 @@
 
 https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md
 """
-from enum import Enum
 
 
-class CompletionItemKind(Enum):
+class CompletionItemKind:
     Text = 1
     Method = 2
     Function = 3
@@ -34,32 +33,32 @@ class CompletionItemKind(Enum):
     TypeParameter = 25
 
 
-class DocumentHighlightKind(Enum):
+class DocumentHighlightKind:
     Text = 1
     Read = 2
     Write = 3
 
 
-class DiagnosticSeverity(Enum):
+class DiagnosticSeverity:
     Error = 1
     Warning = 2
     Information = 3
     Hint = 4
 
 
-class InsertTextFormat(Enum):
+class InsertTextFormat:
     PlainText = 1
     Snippet = 2
 
 
-class MessageType(Enum):
+class MessageType:
     Error = 1
     Warning = 2
     Info = 3
     Log = 4
 
 
-class SymbolKind(Enum):
+class SymbolKind:
     File = 1
     Module = 2
     Namespace = 3
@@ -80,7 +79,7 @@ class SymbolKind(Enum):
     Array = 18
 
 
-class TextDocumentSyncKind(Enum):
+class TextDocumentSyncKind:
     NONE = 0
     FULL = 1
     INCREMENTAL = 2

--- a/pyls/lsp.py
+++ b/pyls/lsp.py
@@ -3,9 +3,10 @@
 
 https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md
 """
+from enum import Enum
 
 
-class CompletionItemKind(object):
+class CompletionItemKind(Enum):
     Text = 1
     Method = 2
     Function = 3
@@ -33,32 +34,32 @@ class CompletionItemKind(object):
     TypeParameter = 25
 
 
-class DocumentHighlightKind(object):
+class DocumentHighlightKind(Enum):
     Text = 1
     Read = 2
     Write = 3
 
 
-class DiagnosticSeverity(object):
+class DiagnosticSeverity(Enum):
     Error = 1
     Warning = 2
     Information = 3
     Hint = 4
 
 
-class InsertTextFormat(object):
+class InsertTextFormat(Enum):
     PlainText = 1
     Snippet = 2
 
 
-class MessageType(object):
+class MessageType(Enum):
     Error = 1
     Warning = 2
     Info = 3
     Log = 4
 
 
-class SymbolKind(object):
+class SymbolKind(Enum):
     File = 1
     Module = 2
     Namespace = 3
@@ -79,7 +80,7 @@ class SymbolKind(object):
     Array = 18
 
 
-class TextDocumentSyncKind(object):
+class TextDocumentSyncKind(Enum):
     NONE = 0
     FULL = 1
     INCREMENTAL = 2

--- a/pyls/plugins/folding.py
+++ b/pyls/plugins/folding.py
@@ -1,4 +1,3 @@
-# pylint: disable=len-as-condition
 # Copyright 2019 Palantir Technologies, Inc.
 
 import re
@@ -175,10 +174,12 @@ def __compute_folding_ranges(tree, lines):
 
     while len(stack) > 0:
         node = stack.pop(0)
+
         if isinstance(node, tree_nodes.Newline):
             # Skip newline nodes
             continue
-        elif isinstance(node, tree_nodes.PythonErrorNode):
+
+        if isinstance(node, tree_nodes.PythonErrorNode):
             # Fallback to indentation-based (best-effort) folding
             start_line, _ = node.start_pos
             start_line -= 1
@@ -188,7 +189,8 @@ def __compute_folding_ranges(tree, lines):
             folding_ranges = __merge_folding_ranges(
                 folding_ranges, identation_ranges)
             break
-        elif not isinstance(node, SKIP_NODES):
+
+        if not isinstance(node, SKIP_NODES):
             valid = __check_if_node_is_valid(node)
             if valid:
                 start_line, end_line, stack = __compute_start_end_lines(

--- a/pyls/plugins/jedi_completion.py
+++ b/pyls/plugins/jedi_completion.py
@@ -51,8 +51,8 @@ class LabelResolver:
                 self._cache[key] = self.resolve_label(completion)
                 self._cache_ttl[self.time_key()].add(key)
             return self._cache[key]
-        else:
-            return self.resolve_label(completion)
+
+        return self.resolve_label(completion)
 
     def _create_completion_id(self, completion: Completion):
         return (
@@ -65,17 +65,17 @@ class LabelResolver:
     def resolve_label(completion):
         try:
             sig = completion.get_signatures()
+
             if sig and completion.type in ('function', 'method'):
                 params = ', '.join(param.name for param in sig[0].params)
                 label = '{}({})'.format(completion.name, params)
                 return label
-            else:
-                return completion.name
-        except Exception as e:
+
+            return completion.name
+        except Exception as e:   # pylint: disable=broad-except
             log.warning(
-                'Something went wrong when resolving label for {completion}: {e}'.format(
-                    completion=completion, e=e
-                )
+                'Something went wrong when resolving label for {completion}: {e}',
+                completion=completion, e=e
             )
 
 

--- a/pyls/plugins/jedi_rename.py
+++ b/pyls/plugins/jedi_rename.py
@@ -11,11 +11,7 @@ def pyls_rename(config, workspace, document, position, new_name):  # pylint: dis
     log.debug('Executing rename of %s to %s', document.word_at_position(position), new_name)
     kwargs = _utils.position_to_jedi_linecolumn(document, position)
     kwargs['new_name'] = new_name
-    try:
-        refactoring = document.jedi_script().rename(**kwargs)
-    except NotImplementedError:
-        raise Exception('No support for renaming in Python 2/3.5 with Jedi. '
-                        'Consider using the rope_rename plugin instead')
+    refactoring = document.jedi_script().rename(**kwargs)
     log.debug('Finished rename: %s', refactoring.get_diff())
     changes = []
     for file_path, changed_file in refactoring.get_changed_files().items():
@@ -43,5 +39,5 @@ def pyls_rename(config, workspace, document, position, new_name):  # pylint: dis
 
 
 def _num_lines(file_contents):
-    'Count the number of lines in the given string.'
+    """Count the number of lines in the given string."""
     return len(file_contents.splitlines())

--- a/pyls/plugins/pycodestyle_lint.py
+++ b/pyls/plugins/pycodestyle_lint.py
@@ -49,7 +49,7 @@ class PyCodeStyleDiagnosticReport(pycodestyle.BaseReport):
 
     def __init__(self, options):
         self.diagnostics = []
-        super(PyCodeStyleDiagnosticReport, self).__init__(options=options)
+        super().__init__(options=options)
 
     def error(self, line_number, offset, text, check):
         code = text[:4]

--- a/pyls/plugins/pyflakes_lint.py
+++ b/pyls/plugins/pyflakes_lint.py
@@ -25,7 +25,7 @@ def pyls_lint(document):
     return reporter.diagnostics
 
 
-class PyflakesDiagnosticReport(object):
+class PyflakesDiagnosticReport:
 
     def __init__(self, lines):
         self.lines = lines

--- a/pyls/plugins/pylint_lint.py
+++ b/pyls/plugins/pylint_lint.py
@@ -17,7 +17,7 @@ except Exception:  # pylint: disable=broad-except
 log = logging.getLogger(__name__)
 
 
-class PylintLinter(object):
+class PylintLinter:
     last_diags = collections.defaultdict(list)
 
     @classmethod

--- a/pyls/plugins/rope_completion.py
+++ b/pyls/plugins/rope_completion.py
@@ -93,7 +93,8 @@ def _sort_text(definition):
     if definition.name.startswith("_"):
         # It's a 'hidden' func, put it next last
         return 'z' + definition.name
-    elif definition.scope == 'builtin':
+
+    if definition.scope == 'builtin':
         return 'y' + definition.name
 
     # Else put it at the front

--- a/pyls/python_ls.py
+++ b/pyls/python_ls.py
@@ -23,13 +23,13 @@ PYTHON_FILE_EXTENSIONS = ('.py', '.pyi')
 CONFIG_FILEs = ('pycodestyle.cfg', 'setup.cfg', 'tox.ini', '.flake8')
 
 
-class _StreamHandlerWrapper(socketserver.StreamRequestHandler, object):
+class _StreamHandlerWrapper(socketserver.StreamRequestHandler):
     """A wrapper class that is used to construct a custom handler class."""
 
     delegate = None
 
     def setup(self):
-        super(_StreamHandlerWrapper, self).setup()
+        super().setup()
         # pylint: disable=no-member
         self.delegate = self.DELEGATE_CLASS(self.rfile, self.wfile)
 
@@ -124,7 +124,7 @@ class PythonLanguageServer(MethodDispatcher):
             raise KeyError
 
         try:
-            return super(PythonLanguageServer, self).__getitem__(item)
+            return super().__getitem__(item)
         except KeyError:
             # Fallback through extra dispatchers
             for dispatcher in self._dispatchers:
@@ -137,7 +137,6 @@ class PythonLanguageServer(MethodDispatcher):
 
     def m_shutdown(self, **_kwargs):
         self._shutdown = True
-        return None
 
     def m_exit(self, **_kwargs):
         self._endpoint.shutdown()

--- a/pyls/uris.py
+++ b/pyls/uris.py
@@ -114,8 +114,6 @@ def _normalize_win_path(path):
         else:
             netloc = path[2:idx]
             path = path[idx:]
-    else:
-        path = path
 
     # Ensure that path starts with a slash
     # or that it is at least a slash

--- a/pyls/workspace.py
+++ b/pyls/workspace.py
@@ -26,7 +26,7 @@ def lock(method):
     return wrapper
 
 
-class Workspace(object):
+class Workspace:
 
     M_PUBLISH_DIAGNOSTICS = 'textDocument/publishDiagnostics'
     M_APPLY_EDIT = 'workspace/applyEdit'
@@ -48,6 +48,7 @@ class Workspace(object):
         self.__rope_config = None
 
     def _rope_project_builder(self, rope_config):
+        # pylint: disable=import-outside-toplevel
         from rope.base.project import Project
 
         # TODO: we could keep track of dirty files and validate only those
@@ -126,7 +127,7 @@ class Workspace(object):
         )
 
 
-class Document(object):
+class Document:
 
     def __init__(self, uri, workspace, source=None, version=None, local=True, extra_sys_path=None,
                  rope_project_builder=None):
@@ -148,6 +149,7 @@ class Document(object):
         return str(self.uri)
 
     def _rope_resource(self, rope_config):
+        # pylint: disable=import-outside-toplevel
         from rope.base import libutils
         return libutils.path_to_resource(self._rope_project_builder(rope_config), self.path)
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -3,6 +3,8 @@ import math
 import os
 import sys
 
+import cProfile
+import jedi
 import pytest
 
 from pyls import uris, lsp
@@ -185,8 +187,6 @@ def test_numpy_completions(config, workspace):
     doc_numpy = "import numpy as np; np."
     com_position = {'line': 0, 'character': len(doc_numpy)}
     doc = Document(DOC_URI, workspace, doc_numpy)
-    import cProfile
-    import jedi
     cProfile.runctx(
         'pyls_jedi_completions(config, doc, com_position)', globals(), locals(),
         f'pyls_jedi_{jedi.__version__}_numpy_completions_1-cache.prof'

--- a/test/test_language_server.py
+++ b/test/test_language_server.py
@@ -19,7 +19,7 @@ def start_client(client):
     client.start()
 
 
-class _ClientServer(object):
+class _ClientServer:
     """ A class to setup a client/server pair """
     def __init__(self, check_parent_process=False):
         # Client to Server pipe
@@ -31,7 +31,7 @@ class _ClientServer(object):
             ParallelKind = Thread
         else:
             if sys.version_info[:2] >= (3, 8):
-                ParallelKind = multiprocessing.get_context("fork").Process  # pylint: disable=no-member
+                ParallelKind = multiprocessing.get_context("fork").Process
             else:
                 ParallelKind = multiprocessing.Process
 


### PR DESCRIPTION
Removes some of the Python 2-specific code, fixes pylint.