### PR TITLE
Update and improve Jedi types map

### DIFF
--- a/pyls/plugins/jedi_completion/__init__.py
+++ b/pyls/plugins/jedi_completion/__init__.py
@@ -26,7 +26,7 @@ LABEL_RESOLVER = LabelResolver(format_label)
 
 # Map to the LSP type
 # > Valid values for type are ``module``, `` class ``, ``instance``, ``function``,
-# > ``param``, ``path``, ``keyword`` and ``statement``.
+# > ``param``, ``path``, ``keyword``, ``property`` and ``statement``.
 # see: https://jedi.readthedocs.io/en/latest/docs/api-classes.html#jedi.api.classes.BaseName.type
 _TYPE_MAP = {
     'module': lsp.CompletionItemKind.Module,
@@ -36,6 +36,7 @@ _TYPE_MAP = {
     'param': lsp.CompletionItemKind.Variable,
     'path': lsp.CompletionItemKind.File,
     'keyword': lsp.CompletionItemKind.Keyword,
+    'property': lsp.CompletionItemKind.Property,
     'statement': lsp.CompletionItemKind.Variable
 }
 

--- a/pyls/plugins/jedi_completion/__init__.py
+++ b/pyls/plugins/jedi_completion/__init__.py
@@ -24,39 +24,19 @@ def format_label(completion, sig):
 LABEL_RESOLVER = LabelResolver(format_label)
 
 
-# Map to the VSCode type
+# Map to the LSP type
+# > Valid values for type are ``module``, `` class ``, ``instance``, ``function``,
+# > ``param``, ``path``, ``keyword`` and ``statement``.
+# see: https://jedi.readthedocs.io/en/latest/docs/api-classes.html#jedi.api.classes.BaseName.type
 _TYPE_MAP = {
-    'none': lsp.CompletionItemKind.Value,
-    'type': lsp.CompletionItemKind.Class,
-    'tuple': lsp.CompletionItemKind.Class,
-    'dict': lsp.CompletionItemKind.Class,
-    'dictionary': lsp.CompletionItemKind.Class,
-    'function': lsp.CompletionItemKind.Function,
-    'lambda': lsp.CompletionItemKind.Function,
-    'generator': lsp.CompletionItemKind.Function,
+    'module': lsp.CompletionItemKind.Module,
     'class': lsp.CompletionItemKind.Class,
     'instance': lsp.CompletionItemKind.Reference,
-    'method': lsp.CompletionItemKind.Method,
-    'builtin': lsp.CompletionItemKind.Class,
-    'builtinfunction': lsp.CompletionItemKind.Function,
-    'module': lsp.CompletionItemKind.Module,
-    'file': lsp.CompletionItemKind.File,
-    'path': lsp.CompletionItemKind.Text,
-    'xrange': lsp.CompletionItemKind.Class,
-    'slice': lsp.CompletionItemKind.Class,
-    'traceback': lsp.CompletionItemKind.Class,
-    'frame': lsp.CompletionItemKind.Class,
-    'buffer': lsp.CompletionItemKind.Class,
-    'dictproxy': lsp.CompletionItemKind.Class,
-    'funcdef': lsp.CompletionItemKind.Function,
-    'property': lsp.CompletionItemKind.Property,
-    'import': lsp.CompletionItemKind.Module,
-    'keyword': lsp.CompletionItemKind.Keyword,
-    'constant': lsp.CompletionItemKind.Variable,
-    'variable': lsp.CompletionItemKind.Variable,
-    'value': lsp.CompletionItemKind.Value,
+    'function': lsp.CompletionItemKind.Function,
     'param': lsp.CompletionItemKind.Variable,
-    'statement': lsp.CompletionItemKind.Keyword,
+    'path': lsp.CompletionItemKind.File,
+    'keyword': lsp.CompletionItemKind.Keyword,
+    'statement': lsp.CompletionItemKind.Variable
 }
 
 # Types of parso nodes for which snippet is not included in the completion

--- a/pyls/plugins/jedi_completion/__init__.py
+++ b/pyls/plugins/jedi_completion/__init__.py
@@ -30,13 +30,14 @@ LABEL_RESOLVER = LabelResolver(format_label)
 # see: https://jedi.readthedocs.io/en/latest/docs/api-classes.html#jedi.api.classes.BaseName.type
 _TYPE_MAP = {
     'module': lsp.CompletionItemKind.Module,
+    'namespace': lsp.CompletionItemKind.Module,    # to be added in Jedi 0.18+
     'class': lsp.CompletionItemKind.Class,
     'instance': lsp.CompletionItemKind.Reference,
     'function': lsp.CompletionItemKind.Function,
     'param': lsp.CompletionItemKind.Variable,
     'path': lsp.CompletionItemKind.File,
     'keyword': lsp.CompletionItemKind.Keyword,
-    'property': lsp.CompletionItemKind.Property,
+    'property': lsp.CompletionItemKind.Property,    # added in Jedi 0.18
     'statement': lsp.CompletionItemKind.Variable
 }
 

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -102,12 +102,30 @@ TYPE_CASES: Dict[str, TypeCase] = {
         position={'line': 0, 'character': 6},
         label='KeyError',
         expected=lsp.CompletionItemKind.Class
+    ),
+    'property': TypeCase(
+        document=(
+            'class A:\n'
+            '    @property\n'
+            '    def test(self):\n'
+            '        pass\n'
+            'A().tes'
+        ),
+        position={'line': 4, 'character': 5},
+        label='test',
+        expected=lsp.CompletionItemKind.Property
     )
 }
 
 
 @pytest.mark.parametrize('case', list(TYPE_CASES.values()), ids=list(TYPE_CASES.keys()))
 def test_jedi_completion_type(case, config, workspace):
+
+    # property support was introduced in 0.18
+    # TODO: remove once 0.18 is required
+    if case.expected == lsp.CompletionItemKind.Property and jedi.__version__.startswith('0.17'):
+        return
+
     doc = Document(DOC_URI, workspace, case.document)
     items = pyls_jedi_completions(config, doc, case.position)
     items = {i['label']: i for i in items}

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -129,7 +129,6 @@ def test_jedi_completion_type(case, config, workspace):
     doc = Document(DOC_URI, workspace, case.document)
     items = pyls_jedi_completions(config, doc, case.position)
     items = {i['label']: i for i in items}
-    print(items)
     assert items[case.label]['kind'] == case.expected
 
 


### PR DESCRIPTION
- changed: `path` semantically means `file` (or folder, but no type for folder) not `text`
- changed: `statement` in Jedi typically means a `variable`, not a `keyword`; there is a separate value for keyword (`keyword`)