### PR TITLE
Improve insertText for keywords always followed by space or colon

### DIFF
--- a/pyls/plugins/jedi_completion/__init__.py
+++ b/pyls/plugins/jedi_completion/__init__.py
@@ -7,7 +7,7 @@ import parso
 from jedi.api.classes import Completion
 from pyls import _utils, hookimpl, lsp
 
-
+from .insert import insert_text
 from .label_resolver import LabelResolver
 from .name_counter import NameCounter
 from .sort import sort_text
@@ -197,7 +197,7 @@ def _format_completion(
         'label': _label(d, resolve_label),
         'kind': _TYPE_MAP.get(d.type),
         'sortText': sort_text(d, relative_frequencies=relative_frequencies, sort_by_count=sort_by_frequency),
-        'insertText': d.name
+        'insertText': insert_text(d.name, d.type)
     }
 
     if resolve:
@@ -232,6 +232,7 @@ def _format_completion(
             completion['insertTextFormat'] = lsp.InsertTextFormat.Snippet
             completion['insertText'] = d.name + '($0)'
         else:
+            # TODO: this looks like it would add parens to keywords too!
             completion['insertText'] = d.name + '()'
 
     return completion

--- a/pyls/plugins/jedi_completion/insert.py
+++ b/pyls/plugins/jedi_completion/insert.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Michal Krassowski
+
+# keywords that are ALWAYS followed by space
+KEYWORDS_FOLLOWED_BY_SPACE = {
+    'as',
+    'assert'
+    'async',
+    'await',
+    'class',
+    'def',
+    'del',
+    'for',
+    'from',
+    'global',
+    'import',
+    'in',
+    'is',
+    'nonlocal',
+    'raise',
+    'while',
+    'with',
+    # conditional
+    'elif'
+    'if',
+    # logical
+    'and',
+    'or',
+    'not',
+}
+# note: 'yield' and 'return' can be followed by space but can also be standalone
+
+# keywords that are ALWAYS followed by colon
+KEYWORDS_FOLLOWED_BY_COLON = {
+    'try',
+    'finally'
+}
+# note: 'else' can be used in a ternary expression: x = 1 if y else 2
+# note: 'lambda' can be followed by colon or argument: lambda: 1 or lambda x: x + 1
+
+
+def insert_text(name: str, completion_type: str):
+    if completion_type == 'keyword':
+        if name in KEYWORDS_FOLLOWED_BY_SPACE:
+            return name + ' '
+        if name in KEYWORDS_FOLLOWED_BY_COLON:
+            return name + ':'
+    return name

--- a/test/plugins/test_completion.py
+++ b/test/plugins/test_completion.py
@@ -15,6 +15,7 @@ from pyls.workspace import Document
 from pyls.plugins.jedi_completion import pyls_completions as pyls_jedi_completions
 from pyls.plugins.jedi_completion import pyls_completion_item_resolve as pyls_jedi_completion_item_resolve
 from pyls.plugins.rope_completion import pyls_completions as pyls_rope_completions
+from pyls.plugins.jedi_completion.insert import insert_text
 
 
 PY2 = sys.version[0] == '2'
@@ -50,6 +51,14 @@ def documented_hello():
     \"\"\"Sends a polite greeting\"\"\"
     pass
 """
+
+
+def test_insert_text():
+    assert insert_text('from', 'keyword') == 'from '
+    assert insert_text('from', 'string') == 'from'
+
+    assert insert_text('try', 'keyword') == 'try:'
+    assert insert_text('try', 'string') == 'try'
 
 
 def test_rope_import_completion(config, workspace):


### PR DESCRIPTION
Adds smarter `insertText` for keywords that are guaranteed to be followed by space or colon in Python. Conservatively does not add space or colon after ambiguous cases of:
- except
- return/yield
- else
- lambda